### PR TITLE
Use Alpine's @click.prevent directive for log out links

### DIFF
--- a/stubs/livewire/resources/views/navigation-menu.blade.php
+++ b/stubs/livewire/resources/views/navigation-menu.blade.php
@@ -109,12 +109,11 @@
                             <div class="border-t border-gray-100"></div>
 
                             <!-- Authentication -->
-                            <form method="POST" action="{{ route('logout') }}">
+                            <form method="POST" action="{{ route('logout') }}" x-data>
                                 @csrf
 
                                 <x-jet-dropdown-link href="{{ route('logout') }}"
-                                         onclick="event.preventDefault();
-                                                this.closest('form').submit();">
+                                         @click.prevent="$root.submit();">
                                     {{ __('Log Out') }}
                                 </x-jet-dropdown-link>
                             </form>
@@ -171,12 +170,11 @@
                 @endif
 
                 <!-- Authentication -->
-                <form method="POST" action="{{ route('logout') }}">
+                <form method="POST" action="{{ route('logout') }}" x-data>
                     @csrf
 
                     <x-jet-responsive-nav-link href="{{ route('logout') }}"
-                                   onclick="event.preventDefault();
-                                    this.closest('form').submit();">
+                                   @click.prevent="$root.submit();">
                         {{ __('Log Out') }}
                     </x-jet-responsive-nav-link>
                 </form>


### PR DESCRIPTION
This PR will switch the ```Log Out``` links in the Livewire navigation menu component from vanilla JS to Alpine's ```@click.prevent``` directive for a cleaner approach with the same result. Also, it should eliminate squawking from IDE's about using the ```event``` context when preventing the default action on clicking the links.